### PR TITLE
Adding support for removing notifications

### DIFF
--- a/EdSnider.Plugins.Core/EdSnider.Plugins.Core.csproj
+++ b/EdSnider.Plugins.Core/EdSnider.Plugins.Core.csproj
@@ -39,6 +39,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="IAppLookupService.cs" />
+    <Compile Include="ILocalNotification.cs" />
     <Compile Include="INotifierService.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/EdSnider.Plugins.Core/ILocalNotification.cs
+++ b/EdSnider.Plugins.Core/ILocalNotification.cs
@@ -1,0 +1,6 @@
+﻿namespace EdSnider.Plugins.Core
+{
+    public interface ILocalNotification
+    {
+    }
+}

--- a/EdSnider.Plugins.Core/INotifierService.cs
+++ b/EdSnider.Plugins.Core/INotifierService.cs
@@ -7,6 +7,13 @@
         /// </summary>
         /// <param name="title">Title of the notification</param>
         /// <param name="body">Body or description of the notification</param>
-        void Show(string title, string body);
+        /// <returns>The notification that was displayed</returns>
+        ILocalNotification Show(string title, string body);
+
+        /// <summary>
+        /// Cancel a local notification
+        /// </summary>
+        /// <param name="notification">The notification to cancel</param>
+        void Hide(ILocalNotification notification);
     }
 }

--- a/Notifier/EdSnider.Plugins.Notifier.Android/EdSnider.Plugins.Notifier.Android.csproj
+++ b/Notifier/EdSnider.Plugins.Notifier.Android/EdSnider.Plugins.Notifier.Android.csproj
@@ -54,6 +54,7 @@
     <Compile Include="..\EdSnider.Plugins.Notifier\Notifier.cs">
       <Link>Notifier.cs</Link>
     </Compile>
+    <Compile Include="LocalNotification.cs" />
     <Compile Include="NotifierService.cs" />
     <Compile Include="Resources\Resource.Designer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Notifier/EdSnider.Plugins.Notifier.Android/LocalNotification.cs
+++ b/Notifier/EdSnider.Plugins.Notifier.Android/LocalNotification.cs
@@ -1,0 +1,24 @@
+﻿using Android.App;
+using Android.Content;
+using EdSnider.Plugins.Core;
+
+namespace EdSnider.Plugins
+{
+    /// <summary>
+    /// Notification implementation for Android
+    /// </summary>
+    public class LocalNotification : ILocalNotification
+    {
+        private readonly int notificationId;
+
+        public LocalNotification(int notificationId)
+        {
+            this.notificationId = notificationId;
+        }
+
+        public int NotificationId
+        {
+            get { return notificationId; }
+        }
+    }
+}

--- a/Notifier/EdSnider.Plugins.Notifier.Android/NotifierService.cs
+++ b/Notifier/EdSnider.Plugins.Notifier.Android/NotifierService.cs
@@ -1,3 +1,4 @@
+using System;
 using Android.App;
 using Android.Content;
 using EdSnider.Plugins.Core;
@@ -14,8 +15,11 @@ namespace EdSnider.Plugins
         /// </summary>
         /// <param name="title">Title of the notification</param>
         /// <param name="body">Body or description of the notification</param>
-        public void Show(string title, string body)
+        /// <returns>The notification that was displayed</returns>
+        public ILocalNotification Show(string title, string body)
         {
+            var notificationId = Guid.NewGuid().GetHashCode();
+
             var builder = new Notification.Builder(Application.Context);
             builder.SetContentTitle(title);
             builder.SetContentText(body);
@@ -25,7 +29,20 @@ namespace EdSnider.Plugins
 
             var manager = Application.Context.GetSystemService(Context.NotificationService) as NotificationManager;
 
-            manager.Notify(0, notification);
+            manager.Notify(notificationId, notification);
+
+            return new LocalNotification(notificationId);
+        }
+
+        /// <summary>
+        /// Cancel a local notification in the Notification Area and Drawer.
+        /// </summary>
+        /// <param name="notification">The notification to cancel</param>
+        public void Hide(ILocalNotification notification)
+        {
+            var manager = Application.Context.GetSystemService(Context.NotificationService) as NotificationManager;
+
+            manager.Cancel(((LocalNotification)notification).NotificationId);
         }
     }
 }

--- a/Notifier/EdSnider.Plugins.Notifier.WinPhoneSL/EdSnider.Plugins.Notifier.WinPhoneSL.csproj
+++ b/Notifier/EdSnider.Plugins.Notifier.WinPhoneSL/EdSnider.Plugins.Notifier.WinPhoneSL.csproj
@@ -84,6 +84,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="..\EdSnider.Plugins.Notifier.WinRT\LocalNotification.cs">
+      <Link>LocalNotification.cs</Link>
+    </Compile>
     <Compile Include="..\EdSnider.Plugins.Notifier.WinRT\NotifierService.cs">
       <Link>NotifierService.cs</Link>
     </Compile>

--- a/Notifier/EdSnider.Plugins.Notifier.WinRT/EdSnider.Plugins.Notifier.WinRT.csproj
+++ b/Notifier/EdSnider.Plugins.Notifier.WinRT/EdSnider.Plugins.Notifier.WinRT.csproj
@@ -42,6 +42,7 @@
     <Compile Include="..\EdSnider.Plugins.Notifier\Notifier.cs">
       <Link>Notifier.cs</Link>
     </Compile>
+    <Compile Include="LocalNotification.cs" />
     <Compile Include="NotifierService.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/Notifier/EdSnider.Plugins.Notifier.WinRT/LocalNotification.cs
+++ b/Notifier/EdSnider.Plugins.Notifier.WinRT/LocalNotification.cs
@@ -1,0 +1,24 @@
+﻿using Windows.Data.Xml.Dom;
+using Windows.UI.Notifications;
+using EdSnider.Plugins.Core;
+
+namespace EdSnider.Plugins
+{
+    /// <summary>
+    /// Notification implementation for Windows
+    /// </summary>
+    public class LocalNotification : ILocalNotification
+    {
+        private readonly ToastNotification notification;
+
+        public LocalNotification(ToastNotification notification)
+        {
+            this.notification = notification;
+        }
+
+        public ToastNotification ToastNotification
+        {
+            get { return notification; }
+        }
+    }
+}

--- a/Notifier/EdSnider.Plugins.Notifier.WinRT/NotifierService.cs
+++ b/Notifier/EdSnider.Plugins.Notifier.WinRT/NotifierService.cs
@@ -23,7 +23,8 @@ namespace EdSnider.Plugins
         /// </summary>
         /// <param name="title">Title of the notification</param>
         /// <param name="body">Body or description of the notification</param>
-        public void Show(string title, string body)
+        /// <returns>The notification that was displayed</returns>
+        public ILocalNotification Show(string title, string body)
         {
             var xmlData = string.Format(_TOAST_TEXT02_TEMPLATE, title, body);
 
@@ -36,6 +37,18 @@ namespace EdSnider.Plugins
             // Create a toast notifier and show the toast
             var manager = ToastNotificationManager.CreateToastNotifier();
             manager.Show(toast);
+
+            return new LocalNotification(toast);
+        }
+
+        /// <summary>
+        /// Cancel a local toast notification.
+        /// </summary>
+        /// <param name="notification">The notification to cancel</param>
+        public void Hide(ILocalNotification notification)
+        {
+            var manager = ToastNotificationManager.CreateToastNotifier();
+            manager.Hide(((LocalNotification)notification).ToastNotification);
         }
     }
 }

--- a/Notifier/EdSnider.Plugins.Notifier.iOS/EdSnider.Plugins.Notifier.iOS.csproj
+++ b/Notifier/EdSnider.Plugins.Notifier.iOS/EdSnider.Plugins.Notifier.iOS.csproj
@@ -90,6 +90,9 @@
     <StartupObject />
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="..\EdSnider.Plugins.Notifier.iOSClassic\LocalNotification.cs">
+      <Link>LocalNotification.cs</Link>
+    </Compile>
     <Compile Include="..\EdSnider.Plugins.Notifier.iOSClassic\NotifierService.cs">
       <Link>NotifierService.cs</Link>
     </Compile>

--- a/Notifier/EdSnider.Plugins.Notifier.iOSClassic/EdSnider.Plugins.Notifier.iOSClassic.csproj
+++ b/Notifier/EdSnider.Plugins.Notifier.iOSClassic/EdSnider.Plugins.Notifier.iOSClassic.csproj
@@ -81,6 +81,7 @@
     <Compile Include="..\EdSnider.Plugins.Notifier\Notifier.cs">
       <Link>Notifier.cs</Link>
     </Compile>
+    <Compile Include="LocalNotification.cs" />
     <Compile Include="NotifierService.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/Notifier/EdSnider.Plugins.Notifier.iOSClassic/LocalNotification.cs
+++ b/Notifier/EdSnider.Plugins.Notifier.iOSClassic/LocalNotification.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using EdSnider.Plugins.Core;
+#if __UNIFIED__
+using Foundation;
+using UIKit;
+#else
+using MonoTouch.Foundation;
+using MonoTouch.UIKit;
+#endif
+
+namespace EdSnider.Plugins
+{
+    /// <summary>
+    /// Notification implementation for iOS (iPad and iPhone)
+    /// </summary>
+    public class LocalNotification : ILocalNotification
+    {
+        private readonly UILocalNotification notification;
+
+        public LocalNotification(UILocalNotification notification)
+        {
+            this.notification = notification;
+        }
+
+        public UILocalNotification UILocalNotification
+        {
+            get { return notification; }
+        }
+    }
+}

--- a/Notifier/EdSnider.Plugins.Notifier.iOSClassic/NotifierService.cs
+++ b/Notifier/EdSnider.Plugins.Notifier.iOSClassic/NotifierService.cs
@@ -20,7 +20,8 @@ namespace EdSnider.Plugins
         /// </summary>
         /// <param name="title">Title of the notification</param>
         /// <param name="body">Body or description of the notification</param>
-        public void Show(string title, string body)
+        /// <returns>The notification that was displayed</returns>
+        public ILocalNotification Show(string title, string body)
         {
             var notification = new UILocalNotification
             {
@@ -30,6 +31,17 @@ namespace EdSnider.Plugins
             };
 
             UIApplication.SharedApplication.ScheduleLocalNotification(notification);
+
+            return new LocalNotification(notification);
+        }
+
+        /// <summary>
+        /// Cancel a local notification in the Notification Center.
+        /// </summary>
+        /// <param name="notification">The notification to cancel</param>
+        public void Hide(ILocalNotification notification)
+        {
+            UIApplication.SharedApplication.CancelLocalNotification(((LocalNotification)notification).UILocalNotification);
         }
     }
 }

--- a/TestApps/AndroidApp/MainActivity.cs
+++ b/TestApps/AndroidApp/MainActivity.cs
@@ -2,14 +2,13 @@
 using Android.OS;
 using Android.Widget;
 using EdSnider.Plugins;
+using EdSnider.Plugins.Core;
 
 namespace AndroidApp
 {
     [Activity(Label = "AndroidApp", MainLauncher = true, Icon = "@drawable/icon")]
     public class MainActivity : Activity
     {
-        int count = 1;
-
         protected override void OnCreate(Bundle bundle)
         {
             base.OnCreate(bundle);
@@ -18,9 +17,22 @@ namespace AndroidApp
             
             var testNotifierButton = FindViewById<Button>(Resource.Id.TestNotifierButton);
 
+            ILocalNotification notification = null;
+
             testNotifierButton.Click += delegate
             {
-                Notifier.Current.Show("Test", "This is a test notification");
+                notification = Notifier.Current.Show("Test", "This is a test notification");
+            };
+
+            var testNotifierCancelButton = FindViewById<Button>(Resource.Id.TestNotifierCancelButton);
+
+            testNotifierCancelButton.Click += delegate
+            {
+                if (notification != null)
+                {
+                    Notifier.Current.Hide(notification);
+                    notification = null;
+                }
             };
 
             var testAppLookupButton = FindViewById<Button>(Resource.Id.TestAppLookupButton);

--- a/TestApps/AndroidApp/Resources/layout/Main.axml
+++ b/TestApps/AndroidApp/Resources/layout/Main.axml
@@ -9,6 +9,11 @@
         android:layout_height="wrap_content"
         android:text="@string/ShowNotification" />
     <Button
+        android:id="@+id/TestNotifierCancelButton"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/CancelNotification" />
+    <Button
         android:id="@+id/TestAppLookupButton"
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"

--- a/TestApps/AndroidApp/Resources/values/Strings.xml
+++ b/TestApps/AndroidApp/Resources/values/Strings.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="ShowNotification">Show Notification</string>
+    <string name="CancelNotification">Cancel Notification</string>
     <string name="IsAppInstalled">Is Calendar App Installed?</string>
     <string name="ApplicationName">AndroidApp</string>
 </resources>

--- a/TestApps/WinApp/MainPage.xaml
+++ b/TestApps/WinApp/MainPage.xaml
@@ -8,7 +8,11 @@
     mc:Ignorable="d">
 
     <Grid Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
-        <Button Content="Send Toast"
-                Click="SendToastClick"/>
+        <StackPanel VerticalAlignment="Center">
+            <Button Content="Send Toast" HorizontalAlignment="Stretch"
+                    Click="SendToastClick"/>
+            <Button Content="Cancel Toast" HorizontalAlignment="Stretch"
+                    Click="CancelToastClick"/>
+        </StackPanel>
     </Grid>
 </Page>

--- a/TestApps/WinApp/MainPage.xaml.cs
+++ b/TestApps/WinApp/MainPage.xaml.cs
@@ -14,6 +14,7 @@ using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Navigation;
 
 using EdSnider.Plugins;
+using EdSnider.Plugins.Core;
 
 namespace WinApp
 {
@@ -24,9 +25,20 @@ namespace WinApp
             InitializeComponent();
         }
 
+        ILocalNotification notification = null;
+
         private void SendToastClick(object sender, RoutedEventArgs e)
         {
-            Notifier.Current.Show("Test", "This is a test notification");
+            notification = Notifier.Current.Show("Test", "This is a test notification");
+        }
+
+        private void CancelToastClick(object sender, RoutedEventArgs e)
+        {
+            if (notification != null)
+            {
+                Notifier.Current.Hide(notification);
+                notification = null;
+            }
         }
     }
 }

--- a/TestApps/WinPhoneApp/MainPage.xaml
+++ b/TestApps/WinPhoneApp/MainPage.xaml
@@ -9,7 +9,11 @@
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
     <Grid>
-        <Button Content="Send Toast"
-                Click="SendToastClick"/>
+        <StackPanel VerticalAlignment="Center">
+            <Button Content="Send Toast" HorizontalAlignment="Stretch"
+                    Click="SendToastClick"/>
+            <Button Content="Cancel Toast" HorizontalAlignment="Stretch"
+                    Click="CancelToastClick"/>
+        </StackPanel>
     </Grid>
 </Page>

--- a/TestApps/WinPhoneApp/MainPage.xaml.cs
+++ b/TestApps/WinPhoneApp/MainPage.xaml.cs
@@ -13,6 +13,7 @@ using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Navigation;
 using EdSnider.Plugins;
+using EdSnider.Plugins.Core;
 
 namespace WinPhoneApp
 {
@@ -24,10 +25,21 @@ namespace WinPhoneApp
 
             NavigationCacheMode = NavigationCacheMode.Required;
         }
+
+        ILocalNotification notification = null;
         
         private void SendToastClick(object sender, RoutedEventArgs e)
         {
-            Notifier.Current.Show("Test", "This is a test notification");
+            notification = Notifier.Current.Show("Test", "This is a test notification");
+        }
+        
+        private void CancelToastClick(object sender, RoutedEventArgs e)
+        {
+            if (notification != null)
+            {
+                Notifier.Current.Hide(notification);
+                notification = null;
+            }
         }
     }
 }

--- a/TestApps/WinPhoneSLApp/MainPage.xaml
+++ b/TestApps/WinPhoneSLApp/MainPage.xaml
@@ -17,6 +17,8 @@
         <StackPanel VerticalAlignment="Center">
             <Button Content="Send Toast"
                     Click="SendToastClick"/>
+            <Button Content="Cancel Toast"
+                    Click="CancelToastClick"/>
         </StackPanel>
     </Grid>
 </phone:PhoneApplicationPage>

--- a/TestApps/WinPhoneSLApp/MainPage.xaml.cs
+++ b/TestApps/WinPhoneSLApp/MainPage.xaml.cs
@@ -6,6 +6,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Navigation;
 using EdSnider.Plugins;
+using EdSnider.Plugins.Core;
 using Microsoft.Phone.Controls;
 using Microsoft.Phone.Shell;
 using WinPhoneSLApp.Resources;
@@ -18,10 +19,21 @@ namespace WinPhoneSLApp
         {
             InitializeComponent();
         }
-        
+
+        ILocalNotification notification = null;
+
         private void SendToastClick(object sender, RoutedEventArgs e)
         {
-            Notifier.Current.Show("Test", "This is a test notification");
+            notification = Notifier.Current.Show("Test", "This is a test notification");
+        }
+
+        private void CancelToastClick(object sender, RoutedEventArgs e)
+        {
+            if (notification != null)
+            {
+                Notifier.Current.Hide(notification);
+                notification = null;
+            }
         }
     }
 }

--- a/TestApps/iOSApp/TestViewController.cs
+++ b/TestApps/iOSApp/TestViewController.cs
@@ -40,6 +40,7 @@ namespace iOSApp
             View.AutoresizingMask = UIViewAutoresizing.FlexibleWidth | UIViewAutoresizing.FlexibleHeight;
 
             var testNotifierButton = UIButton.FromType(UIButtonType.RoundedRect);
+            var testNotifierCancelButton = UIButton.FromType(UIButtonType.RoundedRect);
             var testAppLookupButton = UIButton.FromType(UIButtonType.RoundedRect);
             
             testNotifierButton.Frame = new RectangleF((float)View.Frame.Width / 2 - 100, 
@@ -47,18 +48,36 @@ namespace iOSApp
                                           200, 
                                           50);
 
-            testAppLookupButton.Frame = new RectangleF((float)View.Frame.Width / 2 - 100,
+            testNotifierCancelButton.Frame = new RectangleF((float)View.Frame.Width / 2 - 100,
                                           (float)testNotifierButton.Frame.Y + (float)testNotifierButton.Frame.Height + 25,
+                                          200,
+                                          50);
+
+            testAppLookupButton.Frame = new RectangleF((float)View.Frame.Width / 2 - 100,
+                                          (float)testNotifierCancelButton.Frame.Y + (float)testNotifierCancelButton.Frame.Height + 25,
                                           200,
                                           50);
 
             testNotifierButton.SetTitle("Show Notification", UIControlState.Normal);
 
+            testNotifierCancelButton.SetTitle("Cancel Notification", UIControlState.Normal);
+
             testAppLookupButton.SetTitle("Is Calendar App Installed", UIControlState.Normal);
+
+            EdSnider.Plugins.Core.ILocalNotification notification = null;
 
             testNotifierButton.TouchUpInside += (sender, args) =>
             {
-                EdSnider.Plugins.Notifier.Current.Show("Test", "This is a test notification");
+                notification = EdSnider.Plugins.Notifier.Current.Show("Test", "This is a test notification");
+            };
+
+            testNotifierCancelButton.TouchUpInside += (sender, args) =>
+            {
+                if (notification != null)
+                {
+                    EdSnider.Plugins.Notifier.Current.Hide(notification);
+                    notification = null;
+                }
             };
 
             testAppLookupButton.TouchUpInside += (sender, args) =>
@@ -82,6 +101,7 @@ namespace iOSApp
                                       UIViewAutoresizing.FlexibleBottomMargin;
 
             View.AddSubview(testNotifierButton);
+            View.AddSubview(testNotifierCancelButton);
             View.AddSubview(testAppLookupButton);
         }
     }


### PR DESCRIPTION
This is a simple addition to enable removal of notifications once they have been dispatched:

``` csharp
// send a notification
var notification = Notifier.Current.Show("Title", "Body");
// cancel it
Notifier.Current.Hide(notification);
```

There is no real change to using it normally, except for the method signature now returns an object.

Currently there is no shared bits in the notification, but this (eg Title and Body properties) can be added.
This simply wraps the native platform notification, and then passes it back to the provider.
