### PR TITLE
Added support to play sound in notifications for iOS and Android

### DIFF
--- a/Notifier/Plugin.LocalNotifications.Abstractions/INotifierService.cs
+++ b/Notifier/Plugin.LocalNotifications.Abstractions/INotifierService.cs
@@ -22,7 +22,8 @@ namespace Plugin.LocalNotifications.Abstractions
         /// <param name="body">Body or description of the notification</param>
         /// <param name="id">Id of the notification</param>
         /// <param name="notifyTime">Time to show notification</param>
-        void Show(string title, string body, int id, DateTime notifyTime);
+        /// <param name="hasSound">Flag to control if notification will play a sound</param>
+        void Show(string title, string body, int id, DateTime notifyTime, bool hasSound = false);
 
         /// <summary>
         /// Cancel a local notification

--- a/Notifier/Plugin.LocalNotifications.Android/LocalNotification.cs
+++ b/Notifier/Plugin.LocalNotifications.Android/LocalNotification.cs
@@ -9,5 +9,6 @@ namespace Plugin.LocalNotifications
         public int Id { get; set; }
         public int IconId { get; set; }
         public DateTime NotifyTime { get; set; }
+        public bool HasSound { get; set; }
     }
 }

--- a/Notifier/Plugin.LocalNotifications.Android/LocalNotificationsImplementation.cs
+++ b/Notifier/Plugin.LocalNotifications.Android/LocalNotificationsImplementation.cs
@@ -64,7 +64,8 @@ namespace Plugin.LocalNotifications
         /// <param name="body">Body or description of the notification</param>
         /// <param name="id">Id of the notification</param>
         /// <param name="notifyTime">The time you would like to schedule the notification for</param>
-        public void Show(string title, string body, int id, DateTime notifyTime)
+		/// <param name="hasSound">Flag to control if notification will play a sound</param>
+        public void Show(string title, string body, int id, DateTime notifyTime, bool hasSound = false)
         {
             var intent = CreateIntent(id);
 
@@ -73,6 +74,7 @@ namespace Plugin.LocalNotifications
             localNotification.Body = body;
             localNotification.Id = id;
             localNotification.NotifyTime = notifyTime;
+            localNotification.HasSound = hasSound;
             if (NotificationIconId != 0)
             {
                 localNotification.IconId = NotificationIconId;

--- a/Notifier/Plugin.LocalNotifications.Android/ScheduledAlarmHandler.cs
+++ b/Notifier/Plugin.LocalNotifications.Android/ScheduledAlarmHandler.cs
@@ -33,6 +33,9 @@ namespace Plugin.LocalNotifications
                 .SetSmallIcon(notification.IconId)
                 .SetAutoCancel(true);
 
+            if (notification.HasSound)
+                builder.SetDefaults((int)NotificationDefaults.Sound);
+
             var resultIntent = LocalNotificationsImplementation.GetLauncherActivity();
             resultIntent.SetFlags(ActivityFlags.NewTask | ActivityFlags.ClearTask);
             var stackBuilder = Android.Support.V4.App.TaskStackBuilder.Create(Application.Context);

--- a/Notifier/Plugin.LocalNotifications.iOSClassic/LocalNotificationsImplementation.cs
+++ b/Notifier/Plugin.LocalNotifications.iOSClassic/LocalNotificationsImplementation.cs
@@ -44,14 +44,16 @@ namespace Plugin.LocalNotifications
         /// <param name="body">Body or description of the notification</param>
         /// <param name="id">Id of the notification</param>
         /// <param name="notifyTime">The time you would like to schedule the notification for</param>
-        public void Show(string title, string body, int id, DateTime notifyTime)
+		/// <param name="hasSound">Flag to control if notification will play a sound</param>
+        public void Show(string title, string body, int id, DateTime notifyTime, bool hasSound = false)
         {
             var notification = new UILocalNotification
             {
                 FireDate = (NSDate)notifyTime,
                 AlertAction = title,
                 AlertBody = body,
-                UserInfo = NSDictionary.FromObjectAndKey(NSObject.FromObject(id), NSObject.FromObject(NotificationKey))
+                UserInfo = NSDictionary.FromObjectAndKey(NSObject.FromObject(id), NSObject.FromObject(NotificationKey)),
+                SoundName = hasSound ? UILocalNotification.DefaultSoundName : null
             };
 
             UIApplication.SharedApplication.ScheduleLocalNotification(notification);


### PR DESCRIPTION
This implementation allow configure if you want play a sound or not.

You only need specify **hasSound** parameter:

```csharp
...
bool hasSound = true;
Notifier.Current.Show(title, body, id, notifyTime, hasSound);
```

This property is false by default.

Initially, only for Android and iOS.